### PR TITLE
Expose $use_ssl flag for backend

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -28,6 +28,8 @@
 #   Sensu backend host used to configure sensuctl and verify API access.
 # @param url_port
 #   Sensu backend port used to configure sensuctl and verify API access.
+# @param use_ssl
+#   Sensu backend service uses SSL
 #
 class sensu::backend (
   Optional[String] $version = undef,

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -40,6 +40,7 @@ class sensu::backend (
   Hash $config_hash = {},
   String $url_host = '127.0.0.1',
   Stdlib::Port $url_port = 8080,
+  Boolean $use_ssl = false,
 ) {
 
   include ::sensu
@@ -69,6 +70,7 @@ class sensu::backend (
     sensu_api_server => $url_host,
     sensu_api_port   => $url_port,
     require          => Service['sensu-backend'],
+    use_ssl          => $use_ssl,
   }
   # Ensure sensu-backend is up before starting sensu-agent
   Sensu_api_validator['sensu'] -> Service['sensu-agent']


### PR DESCRIPTION
# Pull Request Checklist

Fixes `sensu_api_validator` when Backend is using SSL

## Description
Adds a `sensu::backend::use_ssl` parameter (defaults to `false`), so the `sensu_api_validator` Exec can communicate with the Sensu Backend of SSL is enabled.

Right now the Backend has SSL implicitly enabled if `cert-file` and `key-file` are specified in `backend.yml`.  Perhaps the change in this PR could be extended to more explicitly set SSL.

## Related Issue

Fixes https://github.com/sensu/sensu-puppet/issues/1023

## How Has This Been Tested?

### Before

```
$ puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for mgmt01.example.org
Info: Applying configuration version '1545709040'
Notice: /Stage[main]/Sensu::Backend/Service[sensu-backend]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Sensu::Backend/Service[sensu-backend]: Unscheduling refresh on Service[sensu-backend]
Notice: Unable to connect to sensu_api server (http://0.0.0.0:7001): Failed to open TCP connection to 0.0.0.0:7001 (Connection refused - connect(2) for "0.0.0.0" port 7001)
Notice: Failed to connect to sensu_api; sleeping 2 seconds before retry
Notice: Unable to connect to sensu_api server (http://0.0.0.0:7001): wrong status line: "\x15\x03\x01\x00\x02\x02"
Notice: Failed to connect to sensu_api; sleeping 2 seconds before retry
Notice: Unable to connect to sensu_api server (http://0.0.0.0:7001): wrong status line: "\x15\x03\x01\x00\x02\x02"
Notice: Failed to connect to sensu_api; sleeping 2 seconds before retry
Notice: Unable to connect to sensu_api server (http://0.0.0.0:7001): wrong status line: "\x15\x03\x01\x00\x02\x02"
Notice: Failed to connect to sensu_api; sleeping 2 seconds before retry
...
```

### After

```
$ puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for mgmt01.example.org
Info: Applying configuration version '1545709163'
Notice: /Stage[main]/Sensu::Agent/Service[sensu-agent]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Sensu::Agent/Service[sensu-agent]: Unscheduling refresh on Service[sensu-agent]
Notice: Applied catalog in 2.10 seconds
```

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
